### PR TITLE
Stream V2 examples: Adapt to new version of cbor2

### DIFF
--- a/stream_v2/examples/README.md
+++ b/stream_v2/examples/README.md
@@ -31,9 +31,12 @@ cmake --build .
 `client.py` demonstrates how to receive and decode stream V2 data using Python 3. Fields of type `MultiDimArray` and `TypedArray` are represented as `numpy` arrays.
 
 ```sh
-pip install cbor2 dectris-compression~=0.3.0 numpy pyzmq
+pip install cbor2~=6.0.0 dectris-compression~=0.3.0 numpy pyzmq
 python client.py
 ```
 
+Please note that this example requires cbor2 version 6.0.0 or later to work. An example compatible with older versions can be found in the branch [cbor2_version_below_6_0_0].
+
 [dectris-compression]: https://github.com/dectris/compression
 [tinycbor]: https://github.com/intel/tinycbor
+[cbor2_version_below_6_0_0]: https://github.com/dectris/documentation/tree/cbor2_version_below_6_0_0

--- a/stream_v2/examples/client.py
+++ b/stream_v2/examples/client.py
@@ -11,13 +11,13 @@ def decode_multi_dim_array(tag, column_major):
     elif isinstance(contents, (np.ndarray, np.generic)):
         array = contents
     else:
-        raise cbor2.CBORDecodeValueError("expected array or typed array")
+        raise cbor2.CBORDecodeError("expected array or typed array")
     return array.reshape(dimensions, order="F" if column_major else "C")
 
 
 def decode_typed_array(tag, dtype):
     if not isinstance(tag.value, bytes):
-        raise cbor2.CBORDecodeValueError("expected byte string in typed array")
+        raise cbor2.CBORDecodeError("expected byte string in typed array")
     return np.frombuffer(tag.value, dtype=dtype)
 
 
@@ -56,7 +56,7 @@ tag_decoders = {
 }
 
 
-def tag_hook(decoder, tag):
+def tag_hook(tag, immutable):
     tag_decoder = tag_decoders.get(tag.tag)
     return tag_decoder(tag) if tag_decoder else tag
 


### PR DESCRIPTION
With version 6.0.0, cbor2 introduced two breaking changes that affect the Python skript here:

 - The signature of `tag_hook` was changed from `CBORDecoder, CBORTag` to `CBORTag, immutable`.
 - The exception `CBORDecodeValueError` was removed, now a `CBORDecodeError` is used instead.

Fixes #9