### PR TITLE
gh pages: Fix versions of mdbook and mdbook-katex

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Install mdBook
         run: |
           rustup update
-          cargo install mdbook
-          cargo install mdbook-katex
+          cargo install mdbook@0.4.48
+          cargo install mdbook-katex@0.9.4
       - name: Build with mdBook
         run: |
           mdbook build


### PR DESCRIPTION
There is currently no stable release of mdbook-katex that supports mdbook v5, therefore we fix the versions for now.